### PR TITLE
Potential fix for code scanning alert no. 1: Potentially overflowing call to snprintf

### DIFF
--- a/src/engine/engine_util_solve.c
+++ b/src/engine/engine_util_solve.c
@@ -1388,11 +1388,15 @@ int mju_boxQPoption(mjtNum* res, mjtNum* R, int* index,               // outputs
 
     // print iteration info
     if (log) {
-      logptr += snprintf(log+logptr, logsz-logptr,
-                         "iter %-3d:  |grad|: %-8.2g  reduction: %-8.2g  improvement: %-8.4g  "
-                         "linesearch: %g^%-2d  factorized: %d  nfree: %d\n",
-                         iter+1, mju_sqrt(norm2), oldvalue-value, improvement,
-                         backtrack, nstep-1, factorize, nfree);
+      int n = snprintf(log+logptr, logsz-logptr,
+                       "iter %-3d:  |grad|: %-8.2g  reduction: %-8.2g  improvement: %-8.4g  "
+                       "linesearch: %g^%-2d  factorized: %d  nfree: %d\n",
+                       iter+1, mju_sqrt(norm2), oldvalue-value, improvement,
+                       backtrack, nstep-1, factorize, nfree);
+      if (n < 0 || n >= logsz - logptr) {
+        break;  // Prevent buffer overflow
+      }
+      logptr += n;
     }
 
     // accept candidate
@@ -1406,9 +1410,13 @@ int mju_boxQPoption(mjtNum* res, mjtNum* R, int* index,               // outputs
 
   // print final info
   if (log) {
-    snprintf(log+logptr, logsz-logptr, "BOXQP: %s.\n"
-             "iterations= %d,  factorizations= %d,  |grad|= %-12.6g, final value= %-12.6g\n",
-             status_string[status+1], iter, nfactor, mju_sqrt(norm2), value);
+    int n = snprintf(log+logptr, logsz-logptr, "BOXQP: %s.\n"
+                     "iterations= %d,  factorizations= %d,  |grad|= %-12.6g, final value= %-12.6g\n",
+                     status_string[status+1], iter, nfactor, mju_sqrt(norm2), value);
+    if (n < 0 || n >= logsz - logptr) {
+      return -1;  // Prevent buffer overflow
+    }
+    logptr += n;
   }
 
   // return nf or -1 if failure


### PR DESCRIPTION
Potential fix for [https://github.com/octodevark/mujoco/security/code-scanning/1](https://github.com/octodevark/mujoco/security/code-scanning/1)

To fix the issue, the return value of `snprintf` should be checked to ensure it does not exceed the remaining buffer size (`logsz-logptr`). If the return value is negative or greater than or equal to the remaining buffer size, the operation should be terminated to prevent buffer overflow. This involves adding a conditional check after the `snprintf` call and updating `logptr` only if the return value is valid.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
